### PR TITLE
Increase remaining days until cert renewal to 32 from 30

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -16,4 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 node.default['acme']['contact'] = 'mailto:letsencrypt@osuosl.org'
+node.default['acme']['renew'] = 32
+
 include_recipe 'acme'


### PR DESCRIPTION
This will stop Nagios from warning us about LetsEncrypt certificates expiring shortly before they're automatically renewed.

See [here](https://github.com/schubergphilis/chef-acme) for info about LE attributes.