### PR TITLE
Updated chefspec platforms for Centos 6, Centos 7 for osl-acme

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,12 +5,12 @@ ChefSpec::Coverage.start! { add_filter 'osl-acme' }
 
 CENTOS_7 = {
   platform: 'centos',
-  version: '7.2.1511',
+  version: '7.4.1708',
 }.freeze
 
 CENTOS_6 = {
   platform: 'centos',
-  version: '6.7',
+  version: '6.9',
 }.freeze
 
 ALL_PLATFORMS = [


### PR DESCRIPTION
Updated chefspec platforms for Centos 6, Centos 7 for osl-acme. 