### PR TITLE
Update upstream acme cookbook to ~> 4.1.1

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -9,9 +9,8 @@ description      'Installs/Configures osl-acme'
 long_description 'Installs/Configures osl-acme'
 version          '2.1.0'
 
-depends          'acme', '~> 4.0.0'
+depends          'acme', '~> 4.1.1'
 depends          'osl-letsencrypt-boulder-server'
-depends          'poise-python'
 
 supports         'centos', '~> 6.0'
 supports         'centos', '~> 7.0'


### PR DESCRIPTION
This should pull in support for acme v2 which is now required. In addition,
remove unused poise-pythong dependency.