### PR TITLE
Remove munin references to Berksfile

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,6 @@
 AllCops:
   TargetChefVersion: 16.latest
-ChefModernize/FoodcriticComments:
+Chef/Modernize/FoodcriticComments:
   Enabled: true
-ChefStyle/CopyrightCommentFormat:
+Chef/Style/CopyrightCommentFormat:
   Enabled: true

--- a/Berksfile
+++ b/Berksfile
@@ -1,17 +1,14 @@
-solver :ruby, :required
-
 source 'https://supermarket.chef.io'
 
 solver :ruby, :required
 
 cookbook 'acme_test', path: 'test/cookbooks/acme_test'
 cookbook 'firewall', git: 'git@github.com:osuosl-cookbooks/firewall.git'
-cookbook 'munin', git: 'git@github.com:osuosl-cookbooks/munin'
 cookbook 'osl-apache', git: 'git@github.com:osuosl-cookbooks/osl-apache'
 cookbook 'osl-git', git: 'git@github.com:osuosl-cookbooks/osl-git'
-cookbook 'osl-munin', git: 'git@github.com:osuosl-cookbooks/osl-munin'
 cookbook 'osl-nrpe', git: 'git@github.com:osuosl-cookbooks/osl-nrpe'
 cookbook 'osl-php', git: 'git@github.com:osuosl-cookbooks/osl-php'
+cookbook 'osl-repos', git: 'git@github.com:osuosl-cookbooks/osl-repos'
 cookbook 'osl-rsync', git: 'git@github.com:osuosl-cookbooks/osl-rsync'
 cookbook 'osl-selinux', git: 'git@github.com:osuosl-cookbooks/osl-selinux'
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -10,7 +10,7 @@ version          '3.2.1'
 
 depends          'acme', '~> 4.1.2'
 depends          'osl-git'
-depends          'resolver'
+depends          'resolver', '~> 2.0'
 
 supports         'centos', '~> 7.0'
 supports         'centos', '~> 8.0'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-acme
 # Recipe:: default
 #
-# Copyright:: 2017-2020, Oregon State University
+# Copyright:: 2017-2021, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-acme
 # Recipe:: server
 #
-# Copyright:: 2017-2020, Oregon State University
+# Copyright:: 2017-2021, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/smoke/default/default_test.rb
+++ b/test/smoke/default/default_test.rb
@@ -1,5 +1,3 @@
-# # encoding: utf-8
-
 # Inspec test for recipe osl-acme::default
 
 # The Inspec reference, with examples and extensive documentation, can be

--- a/test/smoke/default/server.rb
+++ b/test/smoke/default/server.rb
@@ -1,5 +1,3 @@
-# # encoding: utf-8
-
 # Inspec test for recipe osl-acme::server
 
 # The Inspec reference, with examples and extensive documentation, can be


### PR DESCRIPTION
Also do some cookstyle fixes along with pinning resolver to the older version (for now) so that tests pass.
