### PR TITLE
Add acme-dns port configuration option

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -10,3 +10,4 @@ default['osl-acme']['acme-dns']['api'] = 'http://ns.acme-dns.osuosl.org'
 default['osl-acme']['acme-dns']['domain'] = 'acme-dns.osuosl.org'
 default['osl-acme']['acme-dns']['nsname'] = 'ns.acme-dns.osuosl.org'
 default['osl-acme']['acme-dns']['nsadmin'] = 'webmaster.osuosl.org'
+default['osl-acme']['acme-dns']['port'] = 80

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -34,8 +34,9 @@ suites:
     attributes:
       osl-acme:
         acme-dns:
+          port: 8000
           ns-address: 192.168.10.1
-          api: http://192.168.10.1
+          api: http://192.168.10.1:8000
           domain: acme-dns.example.org
           nsname: ns.acme-dns.example.org
           nsadmin: test.example.org

--- a/recipes/acme_dns_server.rb
+++ b/recipes/acme_dns_server.rb
@@ -61,7 +61,7 @@ iptables_rule 'Restrict POST /register to localhost' do
   line_number 1
   protocol :tcp
   match 'string'
-  extra_options '--dport 80 --string "POST /register" --algo kmp'
+  extra_options "--dport #{node['osl-acme']['acme-dns']['port']} --string \"POST /register\" --algo kmp"
   jump 'DROP'
 end
 

--- a/templates/default/config.cfg.erb
+++ b/templates/default/config.cfg.erb
@@ -23,7 +23,7 @@ connection = "postgres://<%= @pg_user %>:<%= @pg_pass %>@<%= @pg_host %>/<%= @pg
 [api]
 ip = "0.0.0.0"
 disable_registration = false
-port = "80"
+port = "<%= node['osl-acme']['acme-dns']['port'] %>"
 tls = "none"
 corsorigins = [
     "*"


### PR DESCRIPTION
This adds an attribute to allow customizing the `acme-dns` API port. Needed since port `80` is already in use on `util2`.