### PR TITLE
Test Kitchen Config Refactor

### DIFF
--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -3,7 +3,7 @@ driver:
   name: dokken
   privileged: true  # because Docker and SystemD/Upstart
   chef_image: cincproject/cinc
-  chef_version: <%= ENV['CHEF_VERSION'] || '17' %>
+  chef_version: <%= ENV['CHEF_VERSION'] || '18' %>
   pull_chef_image: false
   pull_platform_image: false
 

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -1,0 +1,23 @@
+---
+driver:
+  name: dokken
+  privileged: true  # because Docker and SystemD/Upstart
+  chef_image: cincproject/cinc
+  chef_version: <%= ENV['CHEF_VERSION'] || '17' %>
+  pull_chef_image: false
+  pull_platform_image: false
+
+transport:
+  name: dokken
+
+provisioner:
+  name: dokken
+  product_name: cinc
+  enforce_idempotency: true
+  chef_binary: /opt/cinc/bin/cinc-client
+
+platforms:
+  - name: almalinux-8
+    driver:
+      image: dokken/almalinux-8
+      pid_one_command: /usr/lib/systemd/systemd

--- a/kitchen.openstack.yml
+++ b/kitchen.openstack.yml
@@ -1,0 +1,28 @@
+---
+driver:
+  name: openstack
+  openstack_username: <%= ENV['OS_USERNAME'] %>
+  openstack_api_key: <%= ENV['OS_PASSWORD'] %>
+  openstack_auth_url: <%= ENV['OS_AUTH_URL'] %>
+  openstack_domain_id: 'default'
+  openstack_project_name: <%= ENV['OS_PROJECT_NAME'] %>
+  openstack_domain_name: <%= ENV['OS_USER_DOMAIN_NAME'] %>
+  floating_ip_pool: <%= ENV['OS_FLOATING_IP_POOL'] %>
+  network_ref: <%= ENV['OS_NETWORK_REF']  %>
+  flavor_ref: <%= ENV['OS_FLAVOR_REF'] %>
+  availability_zone: <%= ENV['OS_AVAILABILITY_ZONE'] || 'nova' %>
+  private_key_path: <%= ENV['OS_PRIVATE_SSH_KEY'] %>
+  key_name: <%= ENV['OS_SSH_KEYPAIR'] %>
+
+transport:
+  name: rsync
+  ssh_key: <%= ENV['OS_PRIVATE_SSH_KEY'] %>
+
+platforms:
+  - name: almalinux-8
+    driver_plugin: openstack
+    driver_config:
+      image_ref: "AlmaLinux 8"
+    transport:
+      username: almalinux
+

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -1,9 +1,17 @@
 ---
 driver:
-   name: openstack
-   flavor_ref: m1.medium
+  name: vagrant
+
+verifier:
+  name: inspec
+
+transport:
+  name: rsync
+
 provisioner:
   name: chef_infra
+  product_name: cinc
+  product_version: '18'
   enforce_idempotency: true
   multiple_converge: 2
   deprecations_as_errors: true
@@ -13,8 +21,9 @@ provisioner:
     osl-selinux:
       enforcing: true
 
-verifier:
-  name: inspec
+platforms:
+  - name: almalinux-8
+
 suites:
   - name: default
     run_list:


### PR DESCRIPTION
All tests green, except for `acme-dns-client` on dokken due to requiring the `dummy` kernel module.