### PR TITLE
Require acme cookbook 4.2.2 for OpenSSL 3.x compatibility

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -8,7 +8,7 @@ source_url       'https://github.com/osuosl-cookbooks/osl-acme'
 description      'Installs/Configures osl-acme'
 version          '4.3.3'
 
-depends          'acme', '~> 4.1.4'
+depends          'acme', '~> 4.2.2'
 depends          'osl-firewall'
 depends          'osl-git'
 depends          'osl-selinux'


### PR DESCRIPTION
The acme cookbook 4.1.x pins acme-client gem 2.0.8, which sets the CSR
version to 2. OpenSSL 3.x (embedded in Cinc Client 18.11) rejects any
CSR version other than 0 per RFC 2986, causing certificate requests to
fail with:

  OpenSSL::X509::RequestError: X509_REQ_set_version: passed invalid argument

acme 4.2.2 defaults to acme-client 2.0.30, which sets the CSR version
to 0 (fixed upstream in acme-client 2.0.19).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Signed-off-by: Lance Albertson <lance@osuosl.org>
